### PR TITLE
Fix/issue 57

### DIFF
--- a/TestProject.OpenSDK/Internal/Helpers/CommandExecutors/ReportingCommandExecutor.cs
+++ b/TestProject.OpenSDK/Internal/Helpers/CommandExecutors/ReportingCommandExecutor.cs
@@ -16,7 +16,6 @@
 
 namespace TestProject.OpenSDK.Internal.Helpers.CommandExecutors
 {
-    using System;
     using System.Collections.Generic;
     using NLog;
     using OpenQA.Selenium.Remote;
@@ -94,17 +93,6 @@ namespace TestProject.OpenSDK.Internal.Helpers.CommandExecutors
                 return;
             }
 
-            Dictionary<string, object> result;
-
-            try
-            {
-                result = (Dictionary<string, object>)response.Value;
-            }
-            catch (InvalidCastException)
-            {
-                result = new Dictionary<string, object>();
-            }
-
             if (StackTraceHelper.Instance.IsRunningInsideWait())
             {
                 // We're only interested in reporting the final FindElement or FindElements call
@@ -113,7 +101,7 @@ namespace TestProject.OpenSDK.Internal.Helpers.CommandExecutors
                     command.Name.Equals(DriverCommand.FindElement) ||
                     command.Name.Equals(DriverCommand.FindElements))
                 {
-                    this.stashedCommand = new StashedCommand(command, result, response.IsPassed());
+                    this.stashedCommand = new StashedCommand(command, response.Value, response.IsPassed());
                 }
 
                 // Do not report the command right away if it's executed inside a WebDriverWait
@@ -127,7 +115,7 @@ namespace TestProject.OpenSDK.Internal.Helpers.CommandExecutors
                 this.stashedCommand = null;
             }
 
-            this.SendCommandToAgent(command, result, response.IsPassed());
+            this.SendCommandToAgent(command, response.Value, response.IsPassed());
         }
 
         /// <summary>
@@ -204,7 +192,7 @@ namespace TestProject.OpenSDK.Internal.Helpers.CommandExecutors
         /// <param name="command">The WebDriver command that was executed.</param>
         /// <param name="result">The result of the command execution.</param>
         /// <param name="passed">True if command execution was successful, false otherwise.</param>
-        private void SendCommandToAgent(Command command, Dictionary<string, object> result, bool passed)
+        private void SendCommandToAgent(Command command, object result, bool passed)
         {
             if (this.ReportsDisabled || this.CommandReportsDisabled)
             {

--- a/TestProject.OpenSDK/Internal/Helpers/CommandExecutors/StashedCommand.cs
+++ b/TestProject.OpenSDK/Internal/Helpers/CommandExecutors/StashedCommand.cs
@@ -16,7 +16,6 @@
 
 namespace TestProject.OpenSDK.Internal.Helpers.CommandExecutors
 {
-    using System.Collections.Generic;
     using OpenQA.Selenium.Remote;
 
     /// <summary>
@@ -32,7 +31,7 @@ namespace TestProject.OpenSDK.Internal.Helpers.CommandExecutors
         /// <summary>
         /// The command execution result.
         /// </summary>
-        public Dictionary<string, object> Result { get; }
+        public object Result { get; }
 
         /// <summary>
         /// True if the command was executed successfully, false otherwise.
@@ -45,7 +44,7 @@ namespace TestProject.OpenSDK.Internal.Helpers.CommandExecutors
         /// <param name="command">WebDriver command executed by the driver.</param>
         /// <param name="result">Result of the command that was executed.</param>
         /// <param name="passed">True if the command was executed successfully, false otherwise.</param>
-        public StashedCommand(Command command, Dictionary<string, object> result, bool passed)
+        public StashedCommand(Command command, object result, bool passed)
         {
             this.Command = command;
             this.Result = result;

--- a/TestProject.OpenSDK/Internal/Rest/Messages/DriverCommandReport.cs
+++ b/TestProject.OpenSDK/Internal/Rest/Messages/DriverCommandReport.cs
@@ -36,7 +36,7 @@ namespace TestProject.OpenSDK.Internal.Rest.Messages
         /// <summary>
         /// The result of the command that was executed.
         /// </summary>
-        public Dictionary<string, object> Result { get; }
+        public object Result { get; }
 
         /// <summary>
         /// True if the command was executed successfully, false otherwise.
@@ -55,7 +55,7 @@ namespace TestProject.OpenSDK.Internal.Rest.Messages
         /// <param name="commandParameters">The command parameters.</param>
         /// <param name="result">Result of the command that was executed.</param>
         /// <param name="passed">True if the command was executed successfully, false otherwise.</param>
-        public DriverCommandReport(string commandName, Dictionary<string, object> commandParameters, Dictionary<string, object> result, bool passed)
+        public DriverCommandReport(string commandName, Dictionary<string, object> commandParameters, object result, bool passed)
         {
             this.CommandName = commandName;
             this.CommandParameters = commandParameters;


### PR DESCRIPTION
This PR fixes issue 57 by allowing driver command execution result data types other than Dictionary<string, object>, which was corrupting / blocking the reporting of several different driver commands.