### PR TITLE
Convert DriverOptions to a data format that preserves capabilities

### DIFF
--- a/TestProject.OpenSDK/Internal/Rest/AgentClient.cs
+++ b/TestProject.OpenSDK/Internal/Rest/AgentClient.cs
@@ -17,7 +17,6 @@
 namespace TestProject.OpenSDK.Internal.Rest
 {
     using System;
-    using System.Collections.Generic;
     using System.Net;
     using Newtonsoft.Json;
     using Newtonsoft.Json.Linq;

--- a/TestProject.OpenSDK/Internal/Rest/Messages/SessionRequest.cs
+++ b/TestProject.OpenSDK/Internal/Rest/Messages/SessionRequest.cs
@@ -16,6 +16,7 @@
 
 namespace TestProject.OpenSDK.Internal.Rest.Messages
 {
+    using System.Collections.Generic;
     using OpenQA.Selenium;
     using TestProject.OpenSDK.Internal.Helpers;
 
@@ -27,7 +28,7 @@ namespace TestProject.OpenSDK.Internal.Rest.Messages
         /// <summary>
         /// Capabilities that should be sent to the Agent for driver initialization.
         /// </summary>
-        public DriverOptions Capabilities { get; }
+        public Dictionary<string, object> Capabilities { get; }
 
         /// <summary>
         /// The current SDK version.
@@ -62,7 +63,8 @@ namespace TestProject.OpenSDK.Internal.Rest.Messages
                 this.JobName = reportSettings.JobName;
             }
 
-            this.Capabilities = capabilities;
+            // Convert DriverOptions to a format that preserves arguments and extensions when serializing it.
+            this.Capabilities = capabilities.ToString().FromJson<Dictionary<string, object>>();
         }
 
         /// <summary>


### PR DESCRIPTION
This PR fixes issue 61 by converting the `DriverOptions` to a data format that preserves capabilities when serializing.