### PR TITLE
Add missing project reference to SpecFlow plugin project

### DIFF
--- a/TestProject.OpenSDK.SpecFlowExamples/TestProject.OpenSDK.SpecFlowExamples.csproj
+++ b/TestProject.OpenSDK.SpecFlowExamples/TestProject.OpenSDK.SpecFlowExamples.csproj
@@ -19,6 +19,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <ProjectReference Include="..\TestProject.OpenSDK.SpecFlowPlugin\TestProject.OpenSDK.SpecFlowPlugin.csproj" />
     <ProjectReference Include="..\TestProject.OpenSDK\TestProject.OpenSDK.csproj" />
   </ItemGroup>
 


### PR DESCRIPTION
This PR reinstates a project reference that (probably) went missing after renaming the SpecFlow plugin project.