### PR TITLE
Fix/issue 47 improve driver shutdown

### DIFF
--- a/TestProject.OpenSDK/Drivers/BaseDriver.cs
+++ b/TestProject.OpenSDK/Drivers/BaseDriver.cs
@@ -21,7 +21,6 @@ namespace TestProject.OpenSDK.Drivers
     using NLog;
     using OpenQA.Selenium;
     using OpenQA.Selenium.Remote;
-    using TestProject.OpenSDK.Drivers.Web;
     using TestProject.OpenSDK.Internal.Addons;
     using TestProject.OpenSDK.Internal.CallStackAnalysis;
     using TestProject.OpenSDK.Internal.Helpers;
@@ -34,7 +33,7 @@ namespace TestProject.OpenSDK.Drivers
     /// Extension of <see cref="OpenQA.Selenium.Chrome.ChromeDriver">ChromeDriver</see> for use with TestProject.
     /// Instead of initializing a new session, it starts it in the TestProject Agent and then reconnects to it.
     /// </summary>
-    public class BaseDriver : OpenQA.Selenium.Remote.RemoteWebDriver, ITestProjectDriver
+    public class BaseDriver : RemoteWebDriver, ITestProjectDriver
     {
         /// <summary>
         /// Flag that indicates whether or not the driver instance is running.
@@ -121,10 +120,17 @@ namespace TestProject.OpenSDK.Drivers
         /// </summary>
         public new void Quit()
         {
-            // Avoid performing the graceful shutdown more than once
-            AppDomain.CurrentDomain.ProcessExit -= (sender, eventArgs) => this.driverShutdownThread.RunThread();
+            if (this.IsRunning)
+            {
+                // Avoid performing the graceful shutdown more than once
+                AppDomain.CurrentDomain.ProcessExit -= (sender, eventArgs) => this.driverShutdownThread.RunThread();
 
-            this.Stop();
+                this.Stop();
+            }
+            else
+            {
+                Logger.Info("Driver is not running, skipping shutdown sequence");
+            }
         }
 
         /// <summary>

--- a/TestProject.OpenSDK/Drivers/Generic/GenericDriver.cs
+++ b/TestProject.OpenSDK/Drivers/Generic/GenericDriver.cs
@@ -18,6 +18,7 @@ namespace TestProject.OpenSDK.Drivers.Generic
 {
     using System;
     using NLog;
+    using TestProject.OpenSDK.Drivers.Web;
     using TestProject.OpenSDK.Internal.CallStackAnalysis;
     using TestProject.OpenSDK.Internal.Helpers.CommandExecutors;
     using TestProject.OpenSDK.Internal.Reporting;
@@ -26,8 +27,13 @@ namespace TestProject.OpenSDK.Drivers.Generic
     /// <summary>
     /// Generic driver that can be used to execute non-UI automation and upload the results to TestProject.
     /// </summary>
-    public class GenericDriver
+    public class GenericDriver : ITestProjectDriver
     {
+        /// <summary>
+        /// Flag that indicates whether or not the driver instance is running.
+        /// </summary>
+        public bool IsRunning { get; private set; }
+
         /// <summary>
         /// The minimum version of the Agent supporting the Generic driver.
         /// </summary>
@@ -84,10 +90,27 @@ namespace TestProject.OpenSDK.Drivers.Generic
         /// </summary>
         public void Quit()
         {
+            if (this.IsRunning)
+            {
+                this.Stop();
+            }
+            else
+            {
+                Logger.Info("Driver is not running, skipping shutdown sequence");
+            }
+        }
+
+        /// <summary>
+        /// Wraps up reporting for the current session.
+        /// </summary>
+        public void Stop()
+        {
             if (!this.commandExecutor.ReportingCommandExecutor.ReportsDisabled)
             {
                 this.commandExecutor.ReportingCommandExecutor.ReportTest(true);
             }
+
+            this.IsRunning = false;
 
             AgentClient.GetInstance().Stop();
         }

--- a/TestProject.OpenSDK/Drivers/ITestProjectDriver.cs
+++ b/TestProject.OpenSDK/Drivers/ITestProjectDriver.cs
@@ -14,7 +14,7 @@
 // limitations under the License.
 // </copyright>
 
-namespace TestProject.OpenSDK.Drivers.Web
+namespace TestProject.OpenSDK.Drivers
 {
     /// <summary>
     /// Interface defining methods that all TestProject driver classes should implement.

--- a/TestProject.OpenSDK/Internal/Helpers/Threading/DriverShutdownThread.cs
+++ b/TestProject.OpenSDK/Internal/Helpers/Threading/DriverShutdownThread.cs
@@ -17,7 +17,7 @@
 namespace TestProject.OpenSDK.Internal.Helpers.Threading
 {
     using NLog;
-    using TestProject.OpenSDK.Drivers.Web;
+    using TestProject.OpenSDK.Drivers;
 
     /// <summary>
     /// A class that spawns a separate thread to gracefully stop a browser session.

--- a/TestProject.OpenSDK/TestProject.OpenSDK.csproj
+++ b/TestProject.OpenSDK/TestProject.OpenSDK.csproj
@@ -21,6 +21,7 @@ From now on, you can effortlessly execute Selenium and Appium native tests using
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Appium.WebDriver" Version="4.3.1" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
     <PackageReference Include="NLog" Version="4.7.5" />
     <PackageReference Include="RestSharp" Version="106.11.7" />


### PR DESCRIPTION
This PR improves the driver shutdown sequence by only attempting to close a driver when the `IsRunning` flag is set to true.