### PR TITLE
Fix/issue 68

### DIFF
--- a/TestProject.OpenSDK.Tests/UnitTests/Internal/Rest/Messages/SessionRequestTest.cs
+++ b/TestProject.OpenSDK.Tests/UnitTests/Internal/Rest/Messages/SessionRequestTest.cs
@@ -1,0 +1,70 @@
+﻿// <copyright file="SessionRequestTest.cs" company="TestProject">
+// Copyright 2020 TestProject (https://testproject.io)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// </copyright>
+
+namespace TestProject.OpenSDK.Tests.UnitTests.Internal.Rest.Messages
+{
+    using Microsoft.VisualStudio.TestTools.UnitTesting;
+    using OpenQA.Selenium.Chrome;
+    using TestProject.OpenSDK.Drivers.Generic;
+    using TestProject.OpenSDK.Drivers.Web;
+    using TestProject.OpenSDK.Internal.Rest.Messages;
+
+    /// <summary>
+    /// Class containing unit tests for the <see cref="SessionRequest"/> class.
+    /// </summary>
+    [TestClass]
+    public class SessionRequestTest
+    {
+        /// <summary>
+        /// Creating a new <see cref="SessionRequest"/> object for a <see cref="GenericDriver"/> should yield expected capabilities.
+        /// </summary>
+        [TestMethod]
+        public void NewSessionRequest_ForGenericDriver_ShouldContainExpectedCapabilities()
+        {
+            GenericOptions genericOptions = new GenericOptions();
+
+            SessionRequest sessionRequest = new SessionRequest(null, genericOptions);
+
+            Assert.AreEqual(1, sessionRequest.Capabilities.Count);
+            Assert.IsTrue(sessionRequest.Capabilities.ContainsKey("PlatformName"));
+
+            sessionRequest.Capabilities.TryGetValue("PlatformName", out object actualPlatformName);
+
+            Assert.AreEqual("ANY", actualPlatformName.ToString());
+        }
+
+        /// <summary>
+        /// Creating a new <see cref="SessionRequest"/> object for a <see cref="ChromeDriver"/> should yield expected capabilities.
+        /// We're only testing this for Chrome, because we're using the Selenium implementation for all drivers other than the <see cref="GenericDriver"/>,
+        /// so there isn't much use in writing tests for all other cases.
+        /// </summary>
+        [TestMethod]
+        public void NewSessionRequest_ForChromeDriver_ShouldContainExpectedCapabilities()
+        {
+            ChromeOptions chromeOptions = new ChromeOptions();
+
+            SessionRequest sessionRequest = new SessionRequest(null, chromeOptions);
+
+            Assert.AreEqual(2, sessionRequest.Capabilities.Count);
+            Assert.IsTrue(sessionRequest.Capabilities.ContainsKey("browserName"));
+            Assert.IsTrue(sessionRequest.Capabilities.ContainsKey("goog:chromeOptions"));
+
+            sessionRequest.Capabilities.TryGetValue("browserName", out object actualBrowserName);
+
+            Assert.AreEqual("chrome", actualBrowserName.ToString());
+        }
+    }
+}

--- a/TestProject.OpenSDK/Drivers/Generic/GenericOptions.cs
+++ b/TestProject.OpenSDK/Drivers/Generic/GenericOptions.cs
@@ -16,6 +16,7 @@
 
 namespace TestProject.OpenSDK.Drivers.Generic
 {
+    using System.Collections.Generic;
     using OpenQA.Selenium;
 
     /// <summary>
@@ -23,6 +24,11 @@ namespace TestProject.OpenSDK.Drivers.Generic
     /// </summary>
     public class GenericOptions : DriverOptions
     {
+        /// <summary>
+        /// The field name for the platform name property to use when creating a serializable dictionary.
+        /// </summary>
+        private readonly string fieldPlatformName = "PlatformName";
+
         /// <summary>
         /// Initializes a new instance of the <see cref="GenericOptions"/> class.
         /// </summary>
@@ -51,6 +57,15 @@ namespace TestProject.OpenSDK.Drivers.Generic
         public override ICapabilities ToCapabilities()
         {
             throw new System.NotImplementedException();
+        }
+
+        /// <summary>
+        /// Returns the current <see cref="GenericOptions"/> object as a <see cref="Dictionary{TKey, TValue}"/>.
+        /// </summary>
+        /// <returns>A <see cref="Dictionary{TKey, TValue}"/> representing the current instance.</returns>
+        public Dictionary<string, object> ToDictionary()
+        {
+            return new Dictionary<string, object>() { { this.fieldPlatformName, this.PlatformName } };
         }
     }
 }

--- a/TestProject.OpenSDK/Internal/Rest/Messages/SessionRequest.cs
+++ b/TestProject.OpenSDK/Internal/Rest/Messages/SessionRequest.cs
@@ -18,6 +18,7 @@ namespace TestProject.OpenSDK.Internal.Rest.Messages
 {
     using System.Collections.Generic;
     using OpenQA.Selenium;
+    using TestProject.OpenSDK.Drivers.Generic;
     using TestProject.OpenSDK.Internal.Helpers;
 
     /// <summary>
@@ -64,7 +65,14 @@ namespace TestProject.OpenSDK.Internal.Rest.Messages
             }
 
             // Convert DriverOptions to a format that preserves arguments and extensions when serializing it.
-            this.Capabilities = capabilities.ToString().FromJson<Dictionary<string, object>>();
+            if (capabilities.GetType().Equals(typeof(GenericOptions)))
+            {
+                this.Capabilities = ((GenericOptions)capabilities).ToDictionary();
+            }
+            else
+            {
+                this.Capabilities = capabilities.ToString().FromJson<Dictionary<string, object>>();
+            }
         }
 
         /// <summary>


### PR DESCRIPTION
This PR adds a custom serialization method for working with GenericOptions for the GenericDriver class, as these cannot be serialized using the default implementation in Selenium, since Selenium does not come with a GenericDriver.

See also issue 68.