### PR TITLE
Fix/target net 461 in specflow plugin

### DIFF
--- a/TestProject.OpenSDK.SpecFlowPlugin/Directory.Build.props
+++ b/TestProject.OpenSDK.SpecFlowPlugin/Directory.Build.props
@@ -1,0 +1,8 @@
+<Project>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.0">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
+    </PackageReference>
+  </ItemGroup>
+</Project>

--- a/TestProject.OpenSDK.SpecFlowPlugin/TestProject.OpenSDK.SpecFlowPlugin.csproj
+++ b/TestProject.OpenSDK.SpecFlowPlugin/TestProject.OpenSDK.SpecFlowPlugin.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFrameworks>net461;netstandard2.0</TargetFrameworks>
     <Title>SpecFlow Plugin for TestProject OpenSDK</Title>
 	  <Description>Reports SpecFlow-based test runs to TestProject Cloud</Description>
     <PackageLicenseFile>LICENSE</PackageLicenseFile>


### PR DESCRIPTION
This PR re-adds .NET 4.6.1 as a target framework for the SpecFlow plugin, following issue 71.