### PR TITLE
Restrict use of SpecFlow plugin to SpecFlow version 3.5

### DIFF
--- a/TestProject.OpenSDK.SpecFlowPlugin/TestProject.OpenSDK.SpecFlowPlugin.csproj
+++ b/TestProject.OpenSDK.SpecFlowPlugin/TestProject.OpenSDK.SpecFlowPlugin.csproj
@@ -26,7 +26,7 @@
 
   <ItemGroup>
     <PackageReference Include="NLog" Version="4.7.6" />
-    <PackageReference Include="SpecFlow" Version="3.5.14" />
+    <PackageReference Include="SpecFlow" Version="[3.5.5,3.6)" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
This PR restricts the SpecFlow plugin to SpecFlow version 3.5 and prevents it from being used with SpecFlow 3.6, which will come with changes that break the current implementation of the plugin.